### PR TITLE
Rider Application Index Page for Admins & Review Page Placeholder

### DIFF
--- a/frontend/src/App.js
+++ b/frontend/src/App.js
@@ -12,6 +12,7 @@ import ShiftPage from "main/pages/ShiftPage";
 import RiderApplicationCreatePage from "main/pages/RiderApplication/RiderApplicationCreatePage";
 import RiderApplicationEditPageMember from "main/pages/RiderApplication/RiderApplicationEditPageMember";
 import RiderApplicationIndexPageMember from "main/pages/RiderApplication/RiderApplicationIndexPageMember";
+import RiderApplicationIndexPageAdmin from "main/pages/RiderApplication/RiderApplicationIndexPageAdmin";
 
 
 import ShiftCreatePage from "main/pages/Shift/ShiftCreatePage";
@@ -68,6 +69,9 @@ function App() {
         }
         {
           (hasRole(currentUser, "ROLE_MEMBER") )&& <Route exact path="/apply/rider/edit/:id" element={<RiderApplicationEditPageMember />} />
+        }
+        {
+          (hasRole(currentUser, "ROLE_ADMIN") )&& <Route exact path="/admin/applications/riders" element={<RiderApplicationIndexPageAdmin />} />
         }
         {  
           (hasRole(currentUser, "ROLE_DRIVER") || hasRole(currentUser, "ROLE_USER")) && (

--- a/frontend/src/App.js
+++ b/frontend/src/App.js
@@ -13,6 +13,7 @@ import RiderApplicationCreatePage from "main/pages/RiderApplication/RiderApplica
 import RiderApplicationEditPageMember from "main/pages/RiderApplication/RiderApplicationEditPageMember";
 import RiderApplicationIndexPageMember from "main/pages/RiderApplication/RiderApplicationIndexPageMember";
 import RiderApplicationIndexPageAdmin from "main/pages/RiderApplication/RiderApplicationIndexPageAdmin";
+import RiderApplicationReviewPage from "main/pages/RiderApplication/RiderApplicationReviewPage"
 
 
 import ShiftCreatePage from "main/pages/Shift/ShiftCreatePage";
@@ -72,6 +73,9 @@ function App() {
         }
         {
           (hasRole(currentUser, "ROLE_ADMIN") )&& <Route exact path="/admin/applications/riders" element={<RiderApplicationIndexPageAdmin />} />
+        }
+        {
+          (hasRole(currentUser, "ROLE_ADMIN") )&& <Route exact path="/admin/applications/riders/review/:id" element={<RiderApplicationReviewPage />} />
         }
         {  
           (hasRole(currentUser, "ROLE_DRIVER") || hasRole(currentUser, "ROLE_USER")) && (

--- a/frontend/src/main/components/Nav/AppNavbar.js
+++ b/frontend/src/main/components/Nav/AppNavbar.js
@@ -102,6 +102,11 @@ export default function AppNavbar({ currentUser, systemInfo, doLogout, currentUr
                   <Nav.Link as={Link} to="/apply/rider">Apply to be a Rider</Nav.Link>
                 )
               }
+              {
+                hasRole(currentUser, "ROLE_ADMIN") && (
+                  <Nav.Link as={Link} to="/admin/applications/riders">Rider Applications</Nav.Link>
+                )
+              }
 
             </Nav>
 

--- a/frontend/src/main/components/Nav/AppNavbar.js
+++ b/frontend/src/main/components/Nav/AppNavbar.js
@@ -9,7 +9,6 @@ function isParticipant(currentUser) {
     hasRole(currentUser, "ROLE_ADMIN")
     || hasRole(currentUser, "ROLE_DRIVER")
     || hasRole(currentUser, "ROLE_RIDER")
-    || hasRole(currentUser, "ROLE_MEMBER")
   );
 }
 

--- a/frontend/src/main/components/Nav/AppNavbar.js
+++ b/frontend/src/main/components/Nav/AppNavbar.js
@@ -9,6 +9,7 @@ function isParticipant(currentUser) {
     hasRole(currentUser, "ROLE_ADMIN")
     || hasRole(currentUser, "ROLE_DRIVER")
     || hasRole(currentUser, "ROLE_RIDER")
+    || hasRole(currentUser, "ROLE_MEMBER")
   );
 }
 

--- a/frontend/src/main/pages/RiderApplication/RiderApplicationIndexPageAdmin.js
+++ b/frontend/src/main/pages/RiderApplication/RiderApplicationIndexPageAdmin.js
@@ -3,8 +3,6 @@ import { useBackend } from 'main/utils/useBackend';
 
 import BasicLayout from "main/layouts/BasicLayout/BasicLayout";
 import {useCurrentUser} from 'main/utils/currentUser'
-// import Button from 'react-bootstrap/Button';
-// import { Link } from 'react-router-dom';
 import RiderApplicationTable from "main/components/RiderApplication/RiderApplicationTable";
 
 export default function RiderApplicationIndexPage() {

--- a/frontend/src/main/pages/RiderApplication/RiderApplicationIndexPageAdmin.js
+++ b/frontend/src/main/pages/RiderApplication/RiderApplicationIndexPageAdmin.js
@@ -1,0 +1,31 @@
+import React from 'react';
+import { useBackend } from 'main/utils/useBackend';
+
+import BasicLayout from "main/layouts/BasicLayout/BasicLayout";
+import {useCurrentUser} from 'main/utils/currentUser'
+import Button from 'react-bootstrap/Button';
+import { Link } from 'react-router-dom';
+import RiderApplicationTable from "main/components/RiderApplication/RiderApplicationTable";
+
+export default function RiderApplicationIndexPage() {
+
+    const currentUser = useCurrentUser();
+
+    const { data: riderApplications, error: _error, status: _status } =
+        useBackend(
+            // Stryker disable all : hard to test for query caching
+            ["/api/rider/admin/all"],
+            { method: "GET", url: "/api/rider/admin/all" },
+            []
+            // Stryker restore all 
+    );  
+    
+    return (
+          <BasicLayout>
+              <div className="pt-2">
+                <h1>All Rider Applications</h1>
+                <RiderApplicationTable riderApplications={riderApplications} currentUser={currentUser} />
+              </div>
+          </BasicLayout>
+      );
+}

--- a/frontend/src/main/pages/RiderApplication/RiderApplicationIndexPageAdmin.js
+++ b/frontend/src/main/pages/RiderApplication/RiderApplicationIndexPageAdmin.js
@@ -3,8 +3,8 @@ import { useBackend } from 'main/utils/useBackend';
 
 import BasicLayout from "main/layouts/BasicLayout/BasicLayout";
 import {useCurrentUser} from 'main/utils/currentUser'
-import Button from 'react-bootstrap/Button';
-import { Link } from 'react-router-dom';
+// import Button from 'react-bootstrap/Button';
+// import { Link } from 'react-router-dom';
 import RiderApplicationTable from "main/components/RiderApplication/RiderApplicationTable";
 
 export default function RiderApplicationIndexPage() {

--- a/frontend/src/main/pages/RiderApplication/RiderApplicationIndexPageMember.js
+++ b/frontend/src/main/pages/RiderApplication/RiderApplicationIndexPageMember.js
@@ -10,6 +10,7 @@ import RiderApplicationTable from "main/components/RiderApplication/RiderApplica
 export default function RiderApplicationIndexPage() {
 
     const currentUser = useCurrentUser();
+
     // Stryker disable all
     const currentUserCopy = currentUser.data?.root?.rolesList
         ? {

--- a/frontend/src/main/pages/RiderApplication/RiderApplicationReviewPage.js
+++ b/frontend/src/main/pages/RiderApplication/RiderApplicationReviewPage.js
@@ -1,0 +1,13 @@
+import BasicLayout from "main/layouts/BasicLayout/BasicLayout";
+
+export default function RiderApplicationReviewPage() {
+
+  // Stryker disable all : placeholder for future implementation
+  return (
+    <BasicLayout>
+      <div className="pt-2">
+        <h1>Review page not yet implemented</h1>
+      </div>
+    </BasicLayout>
+  )
+}

--- a/frontend/src/tests/components/Nav/AppNavbar.test.js
+++ b/frontend/src/tests/components/Nav/AppNavbar.test.js
@@ -604,5 +604,58 @@ describe("AppNavbar tests", () => {
         expect(applyMenu).not.toBeInTheDocument();      
     });
 
+    test("renders RiderApplicationAdmin links correctly for admin", async () => {
+
+        const currentUser = currentUserFixtures.adminOnly;
+        const doLogin = jest.fn();
+
+        const { getByText } = render(
+            <QueryClientProvider client={queryClient}>
+                <MemoryRouter>
+                    <AppNavbar currentUser={currentUser} doLogin={doLogin} />
+                    </MemoryRouter>
+            </QueryClientProvider>
+        );
+        
+        await waitFor(() => expect(getByText("Welcome, Phill Conrad")).toBeInTheDocument());
+        await waitFor(() => expect(getByText("Rider Applications")).toBeInTheDocument());      
+    });
+
+    test("not render Rider Application links for member", async () => {
+
+        const currentUser = currentUserFixtures.memberOnly;
+        const doLogin = jest.fn();
+
+        const { getByText } = render(
+            <QueryClientProvider client={queryClient}>
+                <MemoryRouter>
+                    <AppNavbar currentUser={currentUser} doLogin={doLogin} />
+                </MemoryRouter>
+            </QueryClientProvider>
+        );
+        
+        await waitFor(() => expect(getByText("Welcome, Phill Conrad")).toBeInTheDocument());
+        const applyMenu = screen.queryByText("Rider Application");
+        expect(applyMenu).not.toBeInTheDocument();      
+    });
+
+    test("not render Rider Application links for regular user", async () => {
+
+        const currentUser = currentUserFixtures.userOnly;
+        const doLogin = jest.fn();
+
+        const { getByText } = render(
+            <QueryClientProvider client={queryClient}>
+                <MemoryRouter>
+                    <AppNavbar currentUser={currentUser} doLogin={doLogin} />
+                </MemoryRouter>
+            </QueryClientProvider>
+        );
+        
+        await waitFor(() => expect(getByText("Welcome, Phillip Conrad")).toBeInTheDocument());
+        const applyMenu = screen.queryByText("Rider Application");
+        expect(applyMenu).not.toBeInTheDocument();      
+    });
+
 });
 

--- a/frontend/src/tests/pages/RiderApplication/RiderApplicationIndexPageAdmin.test.js
+++ b/frontend/src/tests/pages/RiderApplication/RiderApplicationIndexPageAdmin.test.js
@@ -1,0 +1,114 @@
+import { screen, render, waitFor } from "@testing-library/react";
+import { QueryClient, QueryClientProvider } from "react-query";
+import { MemoryRouter } from "react-router-dom";
+import RiderApplicationIndexPage from "main/pages/RiderApplication/RiderApplicationIndexPageAdmin";
+
+
+import { apiCurrentUserFixtures } from "fixtures/currentUserFixtures";
+import { systemInfoFixtures } from "fixtures/systemInfoFixtures";
+import { riderApplicationFixtures } from "fixtures/riderApplicationFixtures";
+import axios from "axios";
+import AxiosMockAdapter from "axios-mock-adapter";
+import mockConsole from "jest-mock-console";
+
+
+const mockToast = jest.fn();
+jest.mock('react-toastify', () => {
+    const originalModule = jest.requireActual('react-toastify');
+    return {
+        __esModule: true,
+        ...originalModule,
+        toast: (x) => mockToast(x)
+    };
+});
+
+describe("RiderApplicationIndexPage tests", () => {
+
+    const axiosMock =new AxiosMockAdapter(axios);
+
+    const testId = "RiderApplicationTable";
+
+    const setupMemberOnly = () => {
+        axiosMock.reset();
+        axiosMock.resetHistory();
+        axiosMock.onGet("/api/currentUser").reply(200, apiCurrentUserFixtures.memberOnly);
+        axiosMock.onGet("/api/systemInfo").reply(200, systemInfoFixtures.showingNeither);
+    };
+
+    const setupAdminUser = () => {
+        axiosMock.reset();
+        axiosMock.resetHistory();
+        axiosMock.onGet("/api/currentUser").reply(200, apiCurrentUserFixtures.adminUser);
+        axiosMock.onGet("/api/systemInfo").reply(200, systemInfoFixtures.showingNeither);
+    };
+
+    test("does not render for regular member", () => {
+        setupMemberOnly();
+        axiosMock.onGet('/api/rider/admin/all').reply(403, []);
+       
+        axios.get('/api/rider/admin/all')
+            .catch(error => {
+                expect(error.response.status).toBe(403);
+            })
+    });
+
+
+    test("renders without crashing for admin user", () => {
+        setupAdminUser();
+        const queryClient = new QueryClient();
+        axiosMock.onGet("/api/rider/admin/all").reply(200, []);
+
+        render(
+            <QueryClientProvider client={queryClient}>
+                <MemoryRouter>
+                    <RiderApplicationIndexPage />
+                </MemoryRouter>
+            </QueryClientProvider>
+        );
+        const pageTittle = screen.getByText("All Rider Applications");
+        expect(pageTittle).toBeInTheDocument();
+    });
+
+    test("renders three applications without crashing for admin", async () => {
+        setupAdminUser();
+        const queryClient = new QueryClient();
+        axiosMock.onGet("/api/rider/admin/all").reply(200, riderApplicationFixtures.threeApplications);
+
+        const { getByTestId } = render(
+            <QueryClientProvider client={queryClient}>
+                <MemoryRouter>
+                    <RiderApplicationIndexPage />
+                </MemoryRouter>
+            </QueryClientProvider>
+        );
+
+        await waitFor(() => { expect(getByTestId(`${testId}-cell-row-0-col-id`)).toHaveTextContent("2"); });
+        expect(getByTestId(`${testId}-cell-row-1-col-id`)).toHaveTextContent("3");
+        expect(getByTestId(`${testId}-cell-row-2-col-id`)).toHaveTextContent("4");
+
+    });
+
+   
+    test("renders empty table when backend unavailable, admin only", async () => {
+        setupAdminUser();
+
+        const queryClient = new QueryClient();
+        axiosMock.onGet("/api/rider/admin/all").timeout();
+
+        const restoreConsole = mockConsole();
+
+        const { queryByTestId } = render(
+            <QueryClientProvider client={queryClient}>
+                <MemoryRouter>
+                    <RiderApplicationIndexPage />
+                </MemoryRouter>
+            </QueryClientProvider>
+        );
+
+        await waitFor(() => { expect(axiosMock.history.get.length).toBeGreaterThanOrEqual(1); });
+
+        restoreConsole();
+
+        expect(queryByTestId(`${testId}-cell-row-0-col-id`)).not.toBeInTheDocument();
+    });
+});

--- a/frontend/src/tests/pages/RiderApplication/RiderApplicationReviewPage.test.js
+++ b/frontend/src/tests/pages/RiderApplication/RiderApplicationReviewPage.test.js
@@ -1,0 +1,42 @@
+import { render, screen } from "@testing-library/react";
+import RiderApplicationReviewPage from "main/pages/RiderApplication/RiderApplicationReviewPage";
+import { QueryClient, QueryClientProvider } from "react-query";
+import { MemoryRouter } from "react-router-dom";
+
+import { apiCurrentUserFixtures } from "fixtures/currentUserFixtures";
+import { systemInfoFixtures } from "fixtures/systemInfoFixtures";
+import axios from "axios";
+import AxiosMockAdapter from "axios-mock-adapter";
+
+
+describe("RiderApplicationReviewPage tests", () => {
+
+    const axiosMock = new AxiosMockAdapter(axios);
+
+    const setupAdminUser = () => {
+        axiosMock.reset();
+        axiosMock.resetHistory();
+        axiosMock.onGet("/api/currentUser").reply(200, apiCurrentUserFixtures.adminUser);
+        axiosMock.onGet("/api/systemInfo").reply(200, systemInfoFixtures.showingNeither);
+    };
+
+    const queryClient = new QueryClient();
+    test("Renders expected content", () => {
+        // arrange
+
+        setupAdminUser();
+
+        // act
+        render(
+            <QueryClientProvider client={queryClient}>
+                <MemoryRouter>
+                    <RiderApplicationReviewPage />
+                </MemoryRouter>
+            </QueryClientProvider>
+        );
+
+        // assert
+        expect(screen.getByText("Review page not yet implemented")).toBeInTheDocument();
+    });
+
+});


### PR DESCRIPTION
In this PR, I implemented Rider Application Index Page for Admins and a review page placeholder. Now there will be a new link on the navbar that shows "Rider Application," which takes an admin user to /admin/applications/riders. 100% mutation/line coverage.

Running Instance at: https://gride-albert-dev.dokku-03.cs.ucsb.edu/

Screenshots:

- IndexPageAdmin
![image](https://github.com/ucsb-cs156-m23/proj-gauchoride-m23-9am-3/assets/114945790/82bba719-03e1-4407-9f21-b6a694569ad3)

- Review Page Placeholder
![image](https://github.com/ucsb-cs156-m23/proj-gauchoride-m23-9am-3/assets/114945790/704d9c6f-6676-4af9-b5dd-52ebdf7e9249)

An update on the display logic: A member is not a "participant" of the GauchoRide Program and therefore should not have access to Ride Request/Shift Pages. They must apply to be a rider before being able to access these fields. A picture of how this is working is provided below:
![image](https://github.com/ucsb-cs156-m23/proj-gauchoride-m23-9am-3/assets/114945790/1c445835-bdb7-4d71-a3a6-f6a7ed6f644c)
(we do not have ROLE_ADMIN on that page, so we are no longer participants able to see "Ride Request"/"Shift")
