### PR TITLE
Change to App Navbar Shift Table Link

### DIFF
--- a/frontend/src/main/components/Nav/AppNavbar.js
+++ b/frontend/src/main/components/Nav/AppNavbar.js
@@ -84,7 +84,7 @@ export default function AppNavbar({ currentUser, systemInfo, doLogout, currentUr
               {
                 isParticipant(currentUser) && (
                   <NavDropdown title="Shift" id="appnavbar-shift-dropdown" data-testid="appnavbar-shift-dropdown" >
-                    <NavDropdown.Item data-testid="appnavbar-shift-dropdown-table" as={Link} to="/shift/list">Driver Shifts</NavDropdown.Item>
+                    <NavDropdown.Item data-testid="appnavbar-shift-dropdown-table" as={Link} to="/shift/">Driver Shifts</NavDropdown.Item>
                     { createShift(currentUser) }
                     </NavDropdown>
                 )


### PR DESCRIPTION
Made a change to shift table link to so admin does not have to create a shift everytime in order to edit/delete other shifts. All of the images below are what is outputted after selecting "Driver Shifts" under the dropdown "Shift"
Before:
![image](https://github.com/ucsb-cs156-m23/proj-gauchoride-m23-9am-3/assets/92071803/4be71041-eb40-4897-9271-9118398d12e4)

After:
![image](https://github.com/ucsb-cs156-m23/proj-gauchoride-m23-9am-3/assets/92071803/1069066d-2a62-4965-91c3-3d157b5f321b)
